### PR TITLE
feat: "TeXLive Image Bug" issue form + 自动编译复现 workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/texlive-image-bug.yml
+++ b/.github/ISSUE_TEMPLATE/texlive-image-bug.yml
@@ -1,0 +1,104 @@
+name: 🐛 TeXLive 镜像编译 Bug / TeXLive Image Bug
+description: 官方 Overleaf 能编译，但本镜像 (ayaka-notes) 编译不了 / Compiles on official Overleaf, but fails with the ayaka-notes image
+title: "[TeXLive Image Bug]: "
+labels: ["texlive-image-bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈！本模板用于：**在官方 Overleaf 上能正常编译，但用我们的 TeXLive 镜像 (ayaka-notes) 却编译失败**的问题。
+        Thanks for reporting! Use this template when a project **compiles on official Overleaf but fails with our TeXLive image (ayaka-notes)**.
+
+        提交后，机器人会用你提供的 **只读分享链接** 自动下载项目，并在对应镜像里用 `latexmk` 复现编译，然后把日志贴回本 issue。
+        After you submit, a bot downloads the project from your **read-only share link**, reproduces the compile with `latexmk` in the matching image, and posts the logs back here.
+
+        > ⚠️ 链接里的内容会被公开下载与编译，请勿包含隐私/未发表内容。
+        > ⚠️ The linked content will be downloaded and compiled publicly — do not include private/unpublished material.
+
+  - type: input
+    id: share_link
+    attributes:
+      label: Overleaf 只读分享链接 / Overleaf read-only share link
+      description: |
+        在 Overleaf 里：菜单 Menu → Share → 打开 “Anyone with this link can view” → 复制 **View only** 链接（形如 `/read/xxxx#yyyy`）。
+        In Overleaf: Menu → Share → turn on "Anyone with this link can view" → copy the **View only** link (looks like `/read/xxxx#yyyy`).
+      placeholder: https://www.overleaf.com/read/xxxxxxxxxxxx#yyyyyy
+    validations:
+      required: true
+
+  - type: dropdown
+    id: compiler
+    attributes:
+      label: 编译器 / Compiler
+      description: |
+        在 Overleaf 左下角 Menu → Settings → Compiler 查看；不确定就选自动检测。
+        Check it in Overleaf: Menu → Settings → Compiler. If unsure, pick auto-detect.
+      options:
+        - "自动检测 / Auto-detect"
+        - "pdflatex"
+        - "xelatex"
+        - "lualatex"
+        - "latex (DVI/PDF)"
+      default: 0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: texlive_version
+    attributes:
+      label: TeX Live 版本 / TeX Live version
+      description: |
+        在 Overleaf Menu → Settings → TeX Live version 查看；不确定就选自动（用最新）。
+        Check it in Overleaf: Menu → Settings → TeX Live version. If unsure, pick auto (latest).
+      options:
+        - "自动 / Auto (latest)"
+        - "2026"
+        - "2025"
+        - "2024"
+        - "2023"
+        - "2022"
+        - "2021"
+        - "2020"
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: main_file
+    attributes:
+      label: 主文件路径（可选）/ Main file path (optional)
+      description: |
+        主 .tex 文件相对路径；留空则自动检测（找含 \documentclass 与 \begin{document} 的文件）。
+        Relative path to the main .tex; leave empty to auto-detect (the file with \documentclass and \begin{document}).
+      placeholder: main.tex
+
+  - type: textarea
+    id: overleaf_evidence
+    attributes:
+      label: Overleaf 能编译的证据 + 本镜像的报错 / Proof it compiles on Overleaf + the error here
+      description: |
+        例如 Overleaf 编译成功的截图，以及你在本镜像/自建 Overleaf 上看到的报错信息。
+        e.g. a screenshot of a successful Overleaf compile, plus the error you see with this image / your self-hosted Overleaf.
+      placeholder: |
+        Overleaf：编译成功（截图） / compiles fine (screenshot)
+        本镜像 / this image: ! LaTeX Error: File `xxx.sty' not found ...
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 其他补充（可选）/ Additional context (optional)
+      description: |
+        用到的特殊宏包/字体、自建 Overleaf 版本、镜像 tag 等。
+        Special packages/fonts used, self-hosted Overleaf version, image tag, etc.
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 确认 / Confirmation
+      options:
+        - label: "该链接是只读分享链接，且任何人可访问 / The link is a read-only share link accessible to anyone"
+          required: true
+        - label: "该项目在官方 Overleaf 上能成功编译 / The project compiles successfully on official Overleaf"
+          required: true
+        - label: "我已确认链接内容可公开 / I confirm the linked content may be public"
+          required: true

--- a/.github/workflows/issue-compile-comment.yml
+++ b/.github/workflows/issue-compile-comment.yml
@@ -1,0 +1,161 @@
+name: Issue Compile Comment
+
+# ┌─ 安全模型 / Security model ───────────────────────────────────────────────┐
+# │ 本工作流拥有写权限（评论 issue、发 release 资产），但它【从不执行】用户     │
+# │ 项目内容 —— 不可信的编译早已在工作流 A 的无 token 沙箱里跑完。             │
+# │ This privileged workflow has write access but NEVER executes user content │
+# │ —— the untrusted compile already ran in workflow A's token-less sandbox.  │
+# │ 这里只读取 A 产出的文件（pdf/log/summary）并贴回 issue。                    │
+# │ It only reads files produced by A (pdf/log/summary) and posts them back.  │
+# │ 所有来自产物的值都经校验，绝不 `source`、绝不内联进 shell。                 │
+# │ All values from the artifact are validated; never `source`d or inlined.   │
+# └───────────────────────────────────────────────────────────────────────────┘
+on:
+  workflow_run:
+    workflows: ["Issue Compile Test"]
+    types: [completed]
+
+permissions:
+  issues: write
+  contents: write # 写 release 资产以托管 pdf/zip / write release assets to host pdf/zip
+  actions: read # 下载来自工作流 A 的 artifact / download workflow A's artifact
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - name: 下载工作流 A 的产物 / download workflow A's artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: compile-result-*
+          merge-multiple: true
+          path: art
+
+      - name: 解析上下文（安全方式，绝不 source）/ parse context (safely, never source)
+        id: ctx
+        run: |
+          set -e
+          if [ ! -f art/ctx.env ]; then
+            echo "没有上下文，跳过 / no context, skipping"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # 仅用 grep 取值，绝不 source 不可信文件 / read with grep only, never source untrusted files
+          getv() { grep -E "^$1=" art/ctx.env | head -1 | cut -d= -f2-; }
+          N="$(getv issue_number)"; EV="$(getv event_name)"; LP="$(getv link_present)"
+          # issue 号必须是纯数字 / issue number must be purely numeric
+          if ! printf '%s' "$N" | grep -qE '^[0-9]+$'; then
+            echo "无有效 issue 号，跳过 / no valid issue number, skipping"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$EV" = "workflow_dispatch" ]; then
+            echo "手动触发，无 issue 可评论 / manual dispatch, nothing to comment"; echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          {
+            echo "skip=0"
+            echo "issue=$N"
+            echo "link_present=$LP"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 托管产物到 Release / host artifacts on a Release
+        id: assets
+        if: steps.ctx.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          N: ${{ steps.ctx.outputs.issue }}
+          RID: ${{ github.event.workflow_run.id }}
+          BASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/compile-logs
+        run: |
+          set -e
+          TAG=compile-logs
+          PREFIX="i${N}-r${RID}"
+          gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 || \
+            gh release create "$TAG" --repo "$REPO" --title "Compile test logs" \
+              --notes "本 release 仅托管 issue 编译测试的日志/PDF。/ Hosts logs & PDFs from issue compile tests." \
+              --prerelease 2>/dev/null || true
+
+          # 把编译产物打成一个 zip（排除上下文/状态文件）/ zip the compiled outputs (excluding context/status files)
+          UP=()
+          if [ -d art ]; then
+            ( cd art && zip -q -r "../${PREFIX}-outputs.zip" . -x ctx.env result.env ) && UP+=("${PREFIX}-outputs.zip") || true
+            [ -f art/output.log ]  && cp art/output.log  "${PREFIX}-output.log"  && UP+=("${PREFIX}-output.log")
+            [ -f art/output.pdf ]  && cp art/output.pdf  "${PREFIX}-output.pdf"  && UP+=("${PREFIX}-output.pdf")
+            [ -f art/preview.png ] && cp art/preview.png "${PREFIX}-preview.png" && UP+=("${PREFIX}-preview.png")
+          fi
+          if [ ${#UP[@]} -gt 0 ]; then
+            gh release upload "$TAG" "${UP[@]}" --repo "$REPO" --clobber || true
+          fi
+          {
+            [ -f "${PREFIX}-outputs.zip" ] && echo "zip_url=${BASE_URL}/${PREFIX}-outputs.zip"
+            [ -f "${PREFIX}-output.log" ] && echo "log_url=${BASE_URL}/${PREFIX}-output.log"
+            [ -f "${PREFIX}-output.pdf" ] && echo "pdf_url=${BASE_URL}/${PREFIX}-output.pdf"
+            [ -f "${PREFIX}-preview.png" ] && echo "preview_url=${BASE_URL}/${PREFIX}-preview.png"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 回贴结果到 issue / comment results back
+        if: steps.ctx.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          N: ${{ steps.ctx.outputs.issue }}
+          LP: ${{ steps.ctx.outputs.link_present }}
+          RID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ZIP_URL: ${{ steps.assets.outputs.zip_url }}
+          LOG_URL: ${{ steps.assets.outputs.log_url }}
+          PDF_URL: ${{ steps.assets.outputs.pdf_url }}
+          PREVIEW_URL: ${{ steps.assets.outputs.preview_url }}
+        run: |
+          {
+            echo "> 🤖 自动编译复现 / automated compile reproduction"
+            echo ">"
+            echo "> **Workflow run ID:** \`${RID}\` · [运行详情 / run details]($RUN_URL)"
+            echo
+            if [ "$LP" != "true" ]; then
+              echo "⚠️ 未能从表单读到合法的 Overleaf 只读分享链接。请编辑 issue 补全后评论 \`/retest-compile\` 重试。"
+              echo "⚠️ No valid Overleaf read-only share link was found in the form. Please edit the issue, then comment \`/retest-compile\` to retry."
+            else
+              echo "**📎 下载 / Downloads**"
+              echo
+              [ -n "$ZIP_URL" ] && echo "- 🗂️ 全部编译产物(zip) / all compiled outputs: [\`outputs.zip\`]($ZIP_URL)"
+              [ -n "$LOG_URL" ] && echo "- 📄 编译日志 / compile log: [\`output.log\`]($LOG_URL)"
+              if [ -n "$PDF_URL" ]; then
+                echo "- 📕 生成的 PDF / compiled PDF: [\`output.pdf\`]($PDF_URL)"
+              else
+                echo "- 📕 生成的 PDF / compiled PDF: ❌ 未生成 / not produced"
+              fi
+              echo
+              if [ -n "$PREVIEW_URL" ]; then
+                echo "**🖼️ PDF 首页预览 / first-page preview**"
+                echo
+                echo "![PDF preview]($PREVIEW_URL)"
+                echo
+              fi
+              if [ -f art/summary.md ]; then
+                cat art/summary.md
+              fi
+            fi
+            echo
+            echo "---"
+            echo "<sub>修好后想重测：编辑 issue 修正信息，然后评论 \`/retest-compile\`。 / To re-test: edit the issue, then comment \`/retest-compile\`.</sub>"
+          } > comment.md
+          gh issue comment "$N" --repo "$REPO" --body-file comment.md
+
+      - name: 打结果标签 / label the result
+        if: steps.ctx.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          N: ${{ steps.ctx.outputs.issue }}
+        run: |
+          gh label create compile-failed --repo "$REPO" --color D73A4A --description "本镜像复现编译失败 / image failed to compile" 2>/dev/null || true
+          gh label create compile-passed --repo "$REPO" --color 0E8A16 --description "本镜像可成功编译 / image compiled successfully" 2>/dev/null || true
+          # 安全读取 pdf 状态：仅 grep，绝不 source / read pdf status safely: grep only, never source
+          PDF="$(grep -E '^pdf=' art/result.env 2>/dev/null | head -1 | cut -d= -f2-)"
+          if [ "$PDF" = "yes" ]; then
+            gh issue edit "$N" --repo "$REPO" --add-label compile-passed --remove-label compile-failed 2>/dev/null || true
+          else
+            gh issue edit "$N" --repo "$REPO" --add-label compile-failed --remove-label compile-passed 2>/dev/null || true
+          fi

--- a/.github/workflows/issue-compile-test.yml
+++ b/.github/workflows/issue-compile-test.yml
@@ -1,0 +1,142 @@
+name: Issue Compile Test
+
+# ┌─ 安全模型 / Security model ───────────────────────────────────────────────┐
+# │ 本工作流会下载并编译“不可信”的用户项目（issue 里的 Overleaf 链接）。       │
+# │ This workflow downloads & compiles an UNTRUSTED user project.             │
+# │ 因此它：                                                                   │
+# │   • 只读权限、没有任何写权限 / read-only, no write permissions             │
+# │   • 不引用任何敏感 secret（仅隐式 GITHUB_TOKEN，且为只读）                  │
+# │     references NO sensitive secrets (only the implicit, read-only token)  │
+# │   • 不评论、不发 release —— 这些交给单独的特权工作流 B 处理                  │
+# │     never comments / writes —— that is done by the separate workflow B    │
+# │ 结果通过 artifact 传给 “Issue Compile Comment” 工作流。                     │
+# │ Results are handed to the "Issue Compile Comment" workflow via artifact.  │
+# └───────────────────────────────────────────────────────────────────────────┘
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      share_link:
+        description: Overleaf 只读分享链接 / Overleaf read-only share link
+        required: true
+      compiler:
+        description: auto | pdflatex | xelatex | lualatex | latex
+        required: false
+        default: auto
+      texlive:
+        description: auto | 2026 | 2025 | 2024 | 2023 | 2022 | 2021 | 2020
+        required: false
+        default: auto
+      main_file:
+        description: 主文件相对路径（可留空）/ main file relative path (optional)
+        required: false
+        default: ""
+
+# 最小权限：只读。无 issues:write，无 contents:write。
+# Least privilege: read-only. No issues:write, no contents:write.
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-compile-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  compile-test:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.labels.*.name, 'texlive-image-bug')) ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.issue.labels.*.name, 'texlive-image-bug') &&
+        startsWith(github.event.comment.body, '/retest-compile'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # TeXLive full 镜像很大（约 30GB），把 docker data-root 迁到更大的 /mnt
+      # The TeXLive full image is huge (~30GB); move docker's data-root to the larger /mnt
+      - name: 给 Docker 腾空间 / give Docker more disk
+        run: |
+          echo "=== before ==="; df -h / /mnt || true
+          sudo systemctl stop docker docker.socket 2>/dev/null || true
+          sudo mkdir -p /mnt/docker
+          echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          sudo docker info 2>/dev/null | grep -i "docker root" || true
+          echo "=== after ==="; df -h / /mnt || true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: 解析输入 / resolve inputs
+        id: inp
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          IN_LINK: ${{ inputs.share_link }}
+          IN_COMPILER: ${{ inputs.compiler }}
+          IN_TEXLIVE: ${{ inputs.texlive }}
+          IN_MAIN: ${{ inputs.main_file }}
+        run: |
+          set -e
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            {
+              echo "link=$IN_LINK"
+              echo "compiler=${IN_COMPILER:-auto}"
+              echo "texlive=${IN_TEXLIVE:-auto}"
+              echo "main=$IN_MAIN"
+            } >> "$GITHUB_OUTPUT"
+          else
+            # ISSUE_BODY 仅经环境变量传入，绝不内联到 shell / passed via env only, never inlined into shell
+            node scripts/parse-issue-form.mjs >> "$GITHUB_OUTPUT"
+          fi
+
+      # 把上下文写给工作流 B（都是可信的 GitHub 内置值）/ write context for workflow B (all trusted GitHub values)
+      - name: 记录上下文 / record context
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          LINK_PRESENT: ${{ steps.inp.outputs.link != '' }}
+        run: |
+          mkdir -p compile-result
+          {
+            echo "issue_number=${ISSUE_NUMBER}"
+            echo "event_name=${EVENT_NAME}"
+            echo "link_present=${LINK_PRESENT}"
+          } > compile-result/ctx.env
+
+      - name: 编译复现 / reproduce the compile
+        if: steps.inp.outputs.link != ''
+        continue-on-error: true
+        env:
+          # 全部经环境变量传入，issue 内容无法被当作 shell 执行；本步骤没有任何 token
+          # everything via env so issue content can't be executed as shell; this step holds NO token
+          LINK: ${{ steps.inp.outputs.link }}
+          COMPILER: ${{ steps.inp.outputs.compiler }}
+          TEXLIVE: ${{ steps.inp.outputs.texlive }}
+          MAIN: ${{ steps.inp.outputs.main }}
+        run: |
+          chmod +x scripts/overleaf-compile-test.sh
+          ./scripts/overleaf-compile-test.sh \
+            --link "$LINK" \
+            --compiler "$COMPILER" \
+            --texlive "$TEXLIVE" \
+            --main "$MAIN" \
+            --out compile-result \
+            --timeout 600
+
+      - name: 上传结果 artifact（供工作流 B 评论使用）/ upload results for workflow B
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-result-${{ github.event.issue.number || github.run_id }}
+          path: compile-result
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,60 @@
+# Overleaf 编译复现工具 / Overleaf compile reproduction tools
+
+用于复现 **“官方 Overleaf 能编译，但本镜像 (ayaka-notes/texlive-full) 编译不了”** 的问题。
+Reproduces **"compiles on official Overleaf, but fails with the ayaka-notes/texlive-full image"** bugs.
+
+## 它是怎么跑的 / How it works
+
+1. `overleaf-fetch.mjs` —— 用 Overleaf **只读分享链接** 拿到匿名会话，下载项目 zip。
+   Uses the Overleaf **read-only share link** to get an anonymous session and download the project zip.
+   - 链接里的 `#xxxx` 锚点会作为 `tokenHashPrefix` 传给 Overleaf 的 grant 接口。
+     The `#xxxx` anchor is passed as `tokenHashPrefix` to Overleaf's grant endpoint.
+   - 安全：只允许 `https://*.overleaf.com`（防 SSRF）。
+     Security: only `https://*.overleaf.com` is allowed (anti-SSRF).
+2. `overleaf-compile-test.sh` —— 解压、确定编译器/TeXLive 年份/主文件，在镜像里用 `latexmk` 编译，收集日志。
+   Unpacks, resolves compiler / TeX Live year / main file, runs `latexmk` in the image, collects logs.
+
+## 用法 / Usage
+
+```bash
+scripts/overleaf-compile-test.sh \
+  --link  "https://www.overleaf.com/read/xxxxxxxxxxxx#yyyyyy" \
+  --compiler auto|pdflatex|xelatex|lualatex|latex \
+  --texlive  auto|2026|2025|2024|2023|2022|2021|2020 \
+  --main     path/to/main.tex \      # 可选 / optional
+  --out      ./compile-result
+```
+
+输出 / Output: `compile-result/` 内含 `output.pdf`、`output.log`、`output.stdout/stderr`、`preview.png`、`summary.md`、`result.env`。
+
+## 与 CLSI 的一致性 / Fidelity to CLSI
+
+编译命令、环境、沙箱均对齐 Overleaf CLSI（`services/clsi`）：
+The compile command, environment and sandbox match Overleaf CLSI (`services/clsi`):
+
+- 命令 / command（`LatexRunner.js`）：
+  `latexmk -cd -jobname=output -auxdir=$COMPILE_DIR -outdir=$COMPILE_DIR -synctex=1 -interaction=batchmode -time -f <engine> $COMPILE_DIR/main.tex`
+- 环境 / env（`DockerRunner.js` / `settings.defaults.js`）：`HOME=/tmp`、`CLSI=1`、`PATH=.../usr/local/texlive/<year>/bin/x86_64-linux/`
+- 沙箱 / sandbox：`--network none`、`--user tex`、`--cap-drop ALL`、`--security-opt no-new-privileges`、
+  `--ulimit cpu=timeout+5:timeout+10`、`--security-opt seccomp=clsi-seccomp.json`（即 CLSI 的 `seccomp/clsi-profile.json`）。
+- `clsi-seccomp.json` 直接取自 Overleaf CLSI。/ vendored verbatim from Overleaf CLSI.
+
+有意的少量差异 / intentional deviations：`--memory=2g`（保护 runner，CLSI 默认实际由 compile group 配置决定）；额外加 `timeout` 墙钟兜底。
+`--memory=2g` (protects the runner; CLSI's real limit comes from compile-group config) and an extra wall-clock `timeout`.
+
+## 安全 / Security
+
+- 所有输入（链接、编译器、年份、主文件）先经**白名单校验**，含非法字符即拒绝；从不内联进 shell。
+  All inputs are **allowlist-validated** and rejected on illegal characters; never inlined into shell.
+- 被编译的 LaTeX 跑在**断网、无密钥**的容器里，即使含 `\write18` 也读不到任何 secret。
+  The compiled LaTeX runs in a **network-less, secret-less** container; even `\write18` can't read any secret.
+- CI 里下载/编译不可信项目的工作流是**只读权限、无 token**；评论/发 release 由单独的特权工作流完成，且它从不执行项目内容。
+  In CI, the workflow that downloads/compiles untrusted projects is **read-only with no token**; commenting is done by a separate privileged workflow that never executes project content.
+
+## 已知限制 / Known limitations
+
+- 仅支持 `/read/` 只读匿名链接；读写匿名链接 overleaf.com 默认禁止。
+  Only anonymous `/read/` links; anonymous read-write links are disabled by overleaf.com.
+- 编译器/年份优先用用户填写；socket 自动探测在 overleaf.com 上不稳定，默认禁用（缺 `ws` 时自动跳过）。
+  Compiler/year come from the user's input first; socket auto-probe is unreliable on overleaf.com and off by default (skipped when `ws` is absent).
+- 不处理 `.Rtex/.Rmd/.md` 的预处理（Overleaf 会先转 `.tex`）。/ no `.Rtex/.Rmd/.md` pre-processing (Overleaf converts to `.tex` first).

--- a/scripts/clsi-seccomp.json
+++ b/scripts/clsi-seccomp.json
@@ -1,0 +1,870 @@
+{
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "architectures": [
+        "SCMP_ARCH_X86_64",
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32",
+        "SCMP_ARCH_AARCH64",
+        "SCMP_ARCH_ARM"
+    ],
+    "syscalls": [
+        {
+          "name": "getrandom",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        },
+        {
+            "name": "access",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "arch_prctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "brk",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "chdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "chmod",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_getres",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_gettime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clock_nanosleep",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "clone",
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 2080505856,
+                    "valueTwo": 0,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ]
+        },
+        {
+            "name": "clone3",
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 38
+        },
+        {
+            "name": "close",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "copy_file_range",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "creat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "dup3",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "execve",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "execveat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "exit",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "exit_group",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "faccessat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fadvise64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fadvise64_64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fallocate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchmod",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchmodat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fcntl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fcntl64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fdatasync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fork",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fstatfs64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fsync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ftruncate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ftruncate64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "futex",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "futimesat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getcpu",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getcwd",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getdents",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getdents64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getegid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getegid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "geteuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "geteuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgroups",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getgroups32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpgrp",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getppid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getpriority",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresgid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getresuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getrlimit",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "get_robust_list",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getrusage",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getsid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "gettid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "getuid32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "ioctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "kill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "_llseek",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lseek",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lstat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "lstat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "madvise",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mkdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mkdirat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mmap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mmap2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mprotect",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "mremap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "munmap",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "newfstatat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "open",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "openat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "openat2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pause",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pipe",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pipe2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "prctl",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pread64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "preadv",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "prlimit64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pwrite64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pwritev",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "read",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readlink",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readlinkat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "readv",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rename",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "renameat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "renameat2",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "restart_syscall",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rmdir",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigaction",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigpending",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigprocmask",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigqueueinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigreturn",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigsuspend",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "rt_tgsigqueueinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getaffinity",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getparam",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_get_priority_max",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_get_priority_min",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_getscheduler",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sched_yield",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sendfile",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sendfile64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgroups",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgroups32",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "set_robust_list",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "set_tid_address",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sigaltstack",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "stat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statx",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "stat64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "statfs64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sync",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sync_file_range",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "syncfs",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "sysinfo",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "tgkill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_create",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_delete",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_getoverrun",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_gettime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "timer_settime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "times",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "tkill",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "truncate",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "truncate64",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "umask",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "uname",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "unlink",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "unlinkat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utime",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utimensat",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "utimes",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "vfork",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "vhangup",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "wait4",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "waitid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "write",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "writev",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "pread",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setgid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "setuid",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "capget",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "capset",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+            "name": "fchown",
+            "action": "SCMP_ACT_ALLOW",
+            "args": []
+        },
+        {
+          "name": "gettimeofday",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        }, {
+          "name": "epoll_pwait",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
+        },
+        {
+        "name": "poll",
+        "action": "SCMP_ACT_ALLOW"
+        },
+        {
+        "name": "select",
+        "action": "SCMP_ACT_ALLOW"
+        },
+        {
+        "name": "ppoll",
+        "action": "SCMP_ACT_ALLOW"
+        }
+    ]
+}

--- a/scripts/overleaf-compile-test.sh
+++ b/scripts/overleaf-compile-test.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# ============================================================================
+# 用 ayaka-notes/texlive-full 镜像复现 Overleaf 项目的编译
+# Reproduce an Overleaf project's compile using the ayaka-notes/texlive-full image
+#
+# 它做了什么 / What it does:
+#   1) 从 Overleaf 只读分享链接下载项目 zip / download the project zip from a read share link
+#   2) 解出编译器 / TeXLive 年份 / 主文件 / resolve compiler, TeX Live year, main file
+#   3) 在我们的镜像里用 latexmk 编译（与 Overleaf CLSI 相同的命令）
+#      compile with latexmk inside our image (same command as Overleaf's CLSI)
+#   4) 收集 output.log / stdout / stderr / pdf / collect the logs and pdf
+#
+# 用法 / Usage:
+#   scripts/overleaf-compile-test.sh \
+#       --link  "https://www.overleaf.com/read/xxxx#yyyy" \
+#       [--compiler auto|pdflatex|xelatex|lualatex|latex] \
+#       [--texlive auto|2026|2025|2024|2023|2022|2021|2020] \
+#       [--main   path/to/main.tex] \
+#       [--registry ghcr.io/ayaka-notes/texlive-full] \
+#       [--timeout 600] \
+#       [--out    ./compile-result]
+# ============================================================================
+set -uo pipefail
+
+# ---- 默认值 / defaults ----
+LINK=""
+COMPILER="auto"
+TEXLIVE="auto"
+MAIN=""
+REGISTRY="ghcr.io/ayaka-notes/texlive-full"
+LATEST_YEAR="2025"            # --texlive auto 且无法探测时的兜底 / fallback when auto & undetectable
+TIMEOUT="600"
+OUT="./compile-result"
+IMAGE_USER="tex"             # 与 Overleaf 默认编译镜像一致 / matches Overleaf's default compile image user
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- 解析参数 / parse args ----
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --link)     LINK="$2"; shift 2;;
+    --compiler) COMPILER="$2"; shift 2;;
+    --texlive)  TEXLIVE="$2"; shift 2;;
+    --main)     MAIN="$2"; shift 2;;
+    --registry) REGISTRY="$2"; shift 2;;
+    --timeout)  TIMEOUT="$2"; shift 2;;
+    --out)      OUT="$2"; shift 2;;
+    --user)     IMAGE_USER="$2"; shift 2;;
+    -h|--help)  grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) echo "未知参数 / unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+if [[ -z "$LINK" ]]; then
+  echo "错误：必须提供 --link / Error: --link is required" >&2
+  exit 2
+fi
+
+# 规范化空白输入（来自 issue 表单的 "_No response_" 等）/ normalise empty inputs from issue forms
+norm() { local v="${1//$'\r'/}"; v="$(echo "$v" | xargs 2>/dev/null)"; case "$v" in ""|"_No response_"|"自动检测"|"自动"|"Auto"|"auto"|"Auto-detect"|"Auto (latest)"|"自动 / Auto") echo "auto";; *) echo "$v";; esac; }
+COMPILER="$(norm "$COMPILER")"
+TEXLIVE="$(norm "$TEXLIVE")"
+MAIN_RAW="$MAIN"; MAIN="$(echo "${MAIN//$'\r'/}" | xargs 2>/dev/null)"
+[[ "$MAIN" == "_No response_" ]] && MAIN=""
+
+# ============================================================================
+# 严格校验所有输入，杜绝命令注入 / strictly validate all inputs, no command injection
+# 这些值最终会进入 shell / docker / 网络请求，必须先白名单校验。
+# These values flow into shell / docker / network requests, so allowlist them first.
+# ============================================================================
+fail_input() {
+  echo "❌ 输入校验失败 / invalid input: $1" >&2
+  mkdir -p "$OUT"
+  {
+    echo "## ❌ 输入校验失败 / Invalid input"
+    echo
+    echo "$1"
+    echo
+    echo "请检查 issue 表单内容后重试。/ Please fix the issue form and retry."
+  } > "$OUT/summary.md"
+  echo "status=invalid_input" > "$OUT/result.env"
+  echo "pdf=no" >> "$OUT/result.env"
+  exit 11
+}
+
+# 链接：必须是 https 且主机属于 overleaf.com（防 SSRF），路径/锚点仅限安全字符
+# link: must be https on an overleaf.com host (anti-SSRF); path/anchor restricted to safe chars
+if ! [[ "$LINK" =~ ^https://([a-z0-9-]+\.)*overleaf\.com/(read/[A-Za-z0-9]+|[A-Za-z0-9]+)(#[A-Za-z0-9]+)?$ ]]; then
+  fail_input "Overleaf 链接格式不合法或主机不是 overleaf.com / link is malformed or host is not overleaf.com: \`${LINK}\`"
+fi
+# 编译器白名单 / compiler allowlist
+case "$COMPILER" in auto|pdflatex|xelatex|lualatex|latex) ;; *) fail_input "未知编译器 / unknown compiler: \`${COMPILER}\`";; esac
+# TeXLive 年份白名单 / TeX Live year allowlist
+if ! [[ "$TEXLIVE" =~ ^(auto|202[0-6])$ ]]; then
+  fail_input "TeXLive 版本不合法（仅 2020–2026 或 auto）/ invalid TeX Live version (only 2020–2026 or auto): \`${TEXLIVE}\`"
+fi
+# 主文件：可空；若给定必须是安全的相对 .tex 路径，禁止 .. 与绝对路径
+# main file: optional; if given, must be a safe relative .tex path, no .. and no absolute path
+if [[ -n "$MAIN" ]]; then
+  if [[ "$MAIN" == /* || "$MAIN" == *".."* || ! "$MAIN" =~ ^[A-Za-z0-9._/\ -]+\.tex$ ]]; then
+    fail_input "主文件路径不合法 / invalid main file path: \`${MAIN}\`"
+  fi
+fi
+
+mkdir -p "$OUT"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+SUMMARY="$OUT/summary.md"
+: > "$SUMMARY"
+
+say() { echo "$@"; }
+note() { echo "$@" >> "$SUMMARY"; }
+
+say "==> 1/5 从 Overleaf 下载项目 / downloading project from Overleaf"
+if ! node "$SCRIPT_DIR/overleaf-fetch.mjs" --link "$LINK" --zip "$WORK/project.zip" --meta "$WORK/meta.json"; then
+  note "❌ **下载失败 / Download failed** — 链接可能失效、未开启只读分享，或不是 \`/read/\` 链接。"
+  note "❌ The link may be invalid, link-sharing may be off, or it is not a \`/read/\` link."
+  exit 7
+fi
+
+# 读取元数据（socket 探测到的值，可能为空）/ read metadata (socket-probed values, may be empty)
+META="$WORK/meta.json"
+get_meta() { node -e "const m=require('$META');process.stdout.write(String(m['$1']??''))" 2>/dev/null; }
+PROBED_COMPILER="$(get_meta compiler)"
+PROBED_YEAR="$(get_meta texliveYear)"
+PROBED_MAIN="$(get_meta rootDocPath)"
+PROJECT_NAME="$(get_meta name)"
+
+say "==> 2/5 解压项目 / unpacking project"
+SRC="$WORK/src"
+mkdir -p "$SRC"
+unzip -q -o "$WORK/project.zip" -d "$SRC" || { note "❌ 解压失败 / unzip failed"; exit 8; }
+
+# ---- 解析主文件 / resolve main file ----
+# 优先级 / precedence: 用户指定 > socket 探测 > 自动检测(含 \documentclass 与 \begin{document})
+if [[ -n "$MAIN" ]]; then
+  MAIN_REL="$MAIN"
+elif [[ -n "$PROBED_MAIN" ]]; then
+  MAIN_REL="$PROBED_MAIN"
+else
+  MAIN_REL=""
+fi
+
+find_main() {
+  # 找同时含 \documentclass 和 \begin{document} 的 .tex，取路径最短者 / shortest .tex with both markers
+  local best="" bestdepth=9999 f depth
+  while IFS= read -r -d '' f; do
+    if grep -lqE '\\documentclass' "$f" && grep -lqE '\\begin\{document\}' "$f"; then
+      depth=$(awk -F/ '{print NF}' <<<"$f")
+      if (( depth < bestdepth )); then bestdepth=$depth; best="$f"; fi
+    fi
+  done < <(find "$SRC" -type f -iname '*.tex' -print0)
+  [[ -n "$best" ]] && printf '%s' "${best#$SRC/}"
+}
+
+if [[ -n "$MAIN_REL" && -f "$SRC/$MAIN_REL" ]]; then
+  : # 使用给定值 / use as-is
+else
+  DETECTED_MAIN="$(find_main)"
+  if [[ -z "$DETECTED_MAIN" ]]; then
+    note "❌ **找不到主文件 / Main file not found** — 未发现同时包含 \`\\documentclass\` 和 \`\\begin{document}\` 的 .tex。请在 issue 中填写主文件路径。"
+    note "❌ No .tex containing both \`\\documentclass\` and \`\\begin{document}\` was found. Please specify the main file path in the issue."
+    exit 9
+  fi
+  if [[ -n "$MAIN_REL" ]]; then
+    say "    指定的主文件不存在，改用自动检测 / specified main not found, using auto-detected: $DETECTED_MAIN"
+  fi
+  MAIN_REL="$DETECTED_MAIN"
+fi
+MAIN_DIR="$(dirname "$SRC/$MAIN_REL")"
+MAIN_BASE="$(basename "$MAIN_REL")"
+
+# ---- 解析编译器 / resolve compiler ----
+# 优先级 / precedence: 用户指定 > socket 探测 > 魔法注释 > pdflatex
+detect_compiler_magic() {
+  # % !TeX program = xelatex  /  % !TEX TS-program = lualatex
+  local line
+  line="$(grep -iEm1 '%\s*!\s*(tex\s+program|tex\s+ts-program|program)\s*=' "$SRC/$MAIN_REL" 2>/dev/null)"
+  case "${line,,}" in
+    *xelatex*) echo xelatex;; *lualatex*) echo lualatex;;
+    *pdflatex*) echo pdflatex;; *latex*) echo latex;; *) echo "";;
+  esac
+}
+COMPILER_SRC="用户填写 / user-provided"
+if [[ "$COMPILER" == "auto" ]]; then
+  if [[ -n "$PROBED_COMPILER" ]]; then COMPILER="$PROBED_COMPILER"; COMPILER_SRC="socket 探测 / socket-probed"
+  else
+    M="$(detect_compiler_magic)"
+    if [[ -n "$M" ]]; then COMPILER="$M"; COMPILER_SRC="魔法注释 / magic comment"
+    else COMPILER="pdflatex"; COMPILER_SRC="默认 / default"; fi
+  fi
+fi
+case "$COMPILER" in pdflatex|xelatex|lualatex|latex) ;; *) say "    未知编译器 '$COMPILER'，回退 pdflatex / unknown compiler, fallback pdflatex"; COMPILER="pdflatex"; COMPILER_SRC="回退 / fallback";; esac
+
+# latexmk 引擎参数（与 CLSI 一致）/ latexmk engine flag (matches CLSI)
+case "$COMPILER" in
+  latex)    ENGINE_FLAG="-pdfdvi";;
+  pdflatex) ENGINE_FLAG="-pdf";;
+  xelatex)  ENGINE_FLAG="-xelatex";;
+  lualatex) ENGINE_FLAG="-lualatex";;
+esac
+
+# ---- 解析 TeXLive 年份 / resolve TeX Live year ----
+YEAR_SRC="用户填写 / user-provided"
+if [[ "$TEXLIVE" == "auto" ]]; then
+  if [[ -n "$PROBED_YEAR" ]]; then TEXLIVE="$PROBED_YEAR"; YEAR_SRC="socket 探测 / socket-probed"
+  else TEXLIVE="$LATEST_YEAR"; YEAR_SRC="默认最新 / default latest"; fi
+fi
+IMAGE="${REGISTRY}:${TEXLIVE}.1"
+
+say "==> 3/5 拉取镜像 / pulling image: $IMAGE"
+if ! docker pull "$IMAGE"; then
+  note "❌ **拉取镜像失败 / Failed to pull image** \`$IMAGE\` — 请确认该 TeXLive 年份的镜像存在。"
+  note "❌ Please verify the image for this TeX Live year exists."
+  exit 10
+fi
+
+# ---- 编译命令（复刻 CLSI LatexRunner）/ compile command (replicates CLSI LatexRunner) ----
+# latexmk -cd -jobname=output -auxdir=/compile -outdir=/compile -synctex=1 \
+#         -interaction=batchmode -time -f <engine> /compile/<main>
+LATEXMK_CMD=(latexmk -cd -jobname=output -auxdir=/compile -outdir=/compile \
+  -synctex=1 -interaction=batchmode -time -f "$ENGINE_FLAG" "/compile/$MAIN_BASE")
+
+# 让镜像里的 tex 用户可写 / make the compile dir writable by the image's tex user
+chmod -R a+rwX "$MAIN_DIR" 2>/dev/null || true
+
+say "==> 4/5 编译 / compiling: $COMPILER on TeXLive $TEXLIVE (main: $MAIN_REL)"
+say "    docker run ... $IMAGE ${LATEXMK_CMD[*]}"
+START=$(date +%s)
+# 与 CLSI 完全一致的容器环境 / container env identical to CLSI
+#   - HOME=/tmp, CLSI=1 (Settings.clsi.docker.env)
+#   - PATH 同 DockerRunner.js（含当年 texlive bin）/ PATH as in DockerRunner.js (with that year's texlive bin)
+TL_BIN="/usr/local/texlive/${TEXLIVE}/bin/x86_64-linux"
+CLSI_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${TL_BIN}/"
+# 沙箱化（对齐 CLSI DockerRunner）：无网络、丢弃全部能力、禁止提权、CPU ulimit、seccomp 白名单
+# Sandbox (matches CLSI DockerRunner): no network, drop ALL caps, no-new-privileges, CPU ulimit, seccomp allowlist
+# 容器内不含任何密钥 / no secrets inside the container.
+SECCOMP_FILE="$SCRIPT_DIR/clsi-seccomp.json"      # 来自 Overleaf CLSI / vendored from Overleaf CLSI
+SECCOMP_OPT=()
+[[ -f "$SECCOMP_FILE" ]] && SECCOMP_OPT=(--security-opt "seccomp=$SECCOMP_FILE")
+docker run --rm \
+  --user "$IMAGE_USER" \
+  --network none \
+  --security-opt no-new-privileges \
+  "${SECCOMP_OPT[@]}" \
+  --cap-drop ALL \
+  --pids-limit 512 \
+  --ulimit "cpu=$((TIMEOUT+5)):$((TIMEOUT+10))" \
+  -v "$MAIN_DIR":/compile \
+  -w /compile \
+  -e HOME=/tmp \
+  -e CLSI=1 \
+  -e PATH="$CLSI_PATH" \
+  --memory=2g \
+  --stop-timeout=10 \
+  "$IMAGE" \
+  timeout "${TIMEOUT}s" "${LATEXMK_CMD[@]}" \
+  > "$OUT/output.stdout" 2> "$OUT/output.stderr"
+STATUS=$?
+END=$(date +%s)
+ELAPSED=$((END-START))
+
+say "==> 5/5 收集日志 / collecting logs"
+# 从编译目录拷出产物 / copy artifacts out of the compile dir
+for f in output.log output.pdf output.synctex.gz output.fls output.fdb_latexmk output.blg; do
+  [[ -f "$MAIN_DIR/$f" ]] && cp "$MAIN_DIR/$f" "$OUT/" 2>/dev/null || true
+done
+
+PDF_OK=no; [[ -f "$OUT/output.pdf" ]] && PDF_OK=yes
+PDF_SIZE=0; [[ -f "$OUT/output.pdf" ]] && PDF_SIZE=$(stat -c%s "$OUT/output.pdf")
+
+# 若有 PDF，用镜像里的 ghostscript 渲染首页预览图（尽力而为）/ if a PDF exists, render a first-page preview via ghostscript (best-effort)
+if [[ "$PDF_OK" == yes ]]; then
+  docker run --rm --user "$IMAGE_USER" -v "$OUT":/d -w /d -e HOME=/tmp "$IMAGE" \
+    gs -dQUIET -dNOPAUSE -dBATCH -sDEVICE=png16m -r100 -dFirstPage=1 -dLastPage=1 \
+       -sOutputFile=/d/preview.png /d/output.pdf >/dev/null 2>&1 || true
+fi
+
+# ---- 生成 summary.md / build summary ----
+{
+  echo "## 🧪 TeXLive 镜像编译测试结果 / TeXLive image compile test result"
+  echo
+  echo "| 项 / Item | 值 / Value |"
+  echo "|---|---|"
+  echo "| 项目 / Project | \`${PROJECT_NAME:-(unknown)}\` |"
+  echo "| 镜像 / Image | \`$IMAGE\` |"
+  echo "| 编译器 / Compiler | \`$COMPILER\` （来源 / source: $COMPILER_SRC） |"
+  echo "| TeXLive 年份 / Year | \`$TEXLIVE\` （来源 / source: $YEAR_SRC） |"
+  echo "| 主文件 / Main file | \`$MAIN_REL\` |"
+  echo "| latexmk 退出码 / exit code | \`$STATUS\` |"
+  echo "| 生成 PDF / PDF produced | $([ "$PDF_OK" = yes ] && echo "✅ 是 / yes ($PDF_SIZE bytes)" || echo "❌ 否 / no") |"
+  echo "| 用时 / Duration | ${ELAPSED}s |"
+  echo
+  if [[ "$PDF_OK" == yes && "$STATUS" -eq 0 ]]; then
+    echo "### ✅ 编译成功 / Compiled successfully"
+    echo "本镜像可以编译该项目。若 Overleaf 同样成功，则非镜像问题；请附上你期望的差异。"
+    echo "This image compiled the project. If Overleaf also succeeds, this is not an image bug; please describe the expected difference."
+  else
+    echo "### ❌ 编译失败 / Compile failed"
+    echo "本镜像未能编译该项目。下方为 \`output.log\` 末尾，完整日志见 Artifacts。"
+    echo "This image failed to compile. The tail of \`output.log\` is below; full logs are attached as artifacts."
+  fi
+  echo
+  echo "<details><summary>output.log (tail 80) </summary>"
+  echo
+  echo '```text'
+  if [[ -f "$OUT/output.log" ]]; then tail -n 80 "$OUT/output.log"; else echo "(no output.log produced)"; fi
+  echo '```'
+  echo "</details>"
+  echo
+  echo "<details><summary>stderr (tail 40)</summary>"
+  echo
+  echo '```text'
+  tail -n 40 "$OUT/output.stderr" 2>/dev/null || true
+  echo '```'
+  echo "</details>"
+} >> "$SUMMARY"
+
+# 机器可读结果 / machine-readable result for the workflow
+{
+  echo "status=$STATUS"
+  echo "pdf=$PDF_OK"
+  echo "image=$IMAGE"
+  echo "compiler=$COMPILER"
+  echo "texlive=$TEXLIVE"
+  echo "main=$MAIN_REL"
+} > "$OUT/result.env"
+
+say ""
+say "结果已写入 / results written to: $OUT"
+say "  - summary.md  (issue 评论用 / for the issue comment)"
+say "  - output.log, output.stdout, output.stderr, output.pdf"
+
+# 编译失败时以非零退出，方便 CI 标红 / non-zero exit on failure so CI marks it red
+[[ "$PDF_OK" == yes && "$STATUS" -eq 0 ]] && exit 0 || exit 1

--- a/scripts/overleaf-fetch.mjs
+++ b/scripts/overleaf-fetch.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// 从 Overleaf 分享链接抓取项目（下载 zip + 尽力探测编译器/TeXLive 版本）
+// Fetch an Overleaf project from a share link (download zip + best-effort detect compiler / TeX Live version).
+//
+// 用法 / Usage:
+//   node overleaf-fetch.mjs --link <share-url> --zip <out.zip> --meta <out.json>
+//
+// 仅依赖 Node 内置 fetch；socket 探测可选依赖 ws（缺失时自动跳过）。
+// Only depends on Node's built-in fetch; the socket probe optionally uses `ws` (skipped if absent).
+
+import { writeFileSync } from 'node:fs'
+
+// ---- 解析命令行参数 / parse CLI args ----
+const args = {}
+for (let i = 2; i < process.argv.length; i++) {
+  const a = process.argv[i]
+  if (a.startsWith('--')) args[a.slice(2)] = process.argv[++i]
+}
+const link = args.link
+const zipOut = args.zip || 'project.zip'
+const metaOut = args.meta || 'meta.json'
+if (!link) {
+  console.error('错误：必须提供 --link / Error: --link is required')
+  process.exit(2)
+}
+
+const UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36'
+
+// ---- 极简 cookie jar / minimal cookie jar ----
+const jar = new Map()
+function storeCookies(res) {
+  const set = res.headers.getSetCookie ? res.headers.getSetCookie() : []
+  for (const c of set) {
+    const [pair] = c.split(';')
+    const idx = pair.indexOf('=')
+    if (idx > 0) jar.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim())
+  }
+}
+function cookieHeader() {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+}
+
+function logStep(msg) {
+  console.error(`[overleaf-fetch] ${msg}`)
+}
+
+// ---- 解析分享链接 / parse the share link ----
+// 支持 / supports:
+//   https://HOST/read/<token>#<hash>      (只读 / read-only)
+//   https://HOST/<token>#<hash>           (读写 / read-write，匿名通常被拒)
+const u = new URL(link)
+// 安全：仅允许 https + overleaf.com 主机（防 SSRF）/ security: only https + overleaf.com hosts (anti-SSRF)
+if (u.protocol !== 'https:' || !/^([a-z0-9-]+\.)*overleaf\.com$/.test(u.hostname)) {
+  console.error(
+    '错误：仅支持 https 的 overleaf.com 链接 / Error: only https overleaf.com links are supported: ' + link
+  )
+  process.exit(3)
+}
+// 锚点仅允许安全字符 / anchor restricted to safe chars
+if (u.hash && !/^#[A-Za-z0-9]+$/.test(u.hash)) {
+  console.error('错误：链接锚点含非法字符 / Error: invalid characters in link anchor')
+  process.exit(3)
+}
+const origin = u.origin
+const hashPrefix = u.hash || '' // 形如 / e.g. "#16fd3a"，作为 tokenHashPrefix 传给 grant
+const segments = u.pathname.split('/').filter(Boolean)
+let token, isReadOnly
+if (segments[0] === 'read' && segments[1]) {
+  token = segments[1]
+  isReadOnly = true
+} else if (segments[0] === 'project' && segments[1]) {
+  // 已经是 /project/<id>，无法匿名访问 / already a project URL, not anonymously accessible
+  console.error(
+    '错误：这是 /project/<id> 链接，需要登录，无法匿名下载。请提供 “只读分享链接”（菜单 → Share → Turn on link sharing → Anyone with this link can view）。\n' +
+      'Error: this is a /project/<id> URL which requires login. Please provide a read-only share link (Menu → Share → Anyone with this link can view).'
+  )
+  process.exit(3)
+} else if (segments.length === 1) {
+  token = segments[0]
+  isReadOnly = false
+} else {
+  console.error('错误：无法识别的 Overleaf 链接 / Error: unrecognized Overleaf link: ' + link)
+  process.exit(3)
+}
+
+async function main() {
+  // 1) 打开分享页，拿到匿名会话 cookie 与 csrf token
+  //    Open the share page to obtain an anonymous session cookie + CSRF token.
+  const pagePath = isReadOnly ? `/read/${token}` : `/${token}`
+  logStep(`打开分享页 / opening share page: ${origin}${pagePath}`)
+  let res = await fetch(origin + pagePath, {
+    headers: { 'User-Agent': UA },
+    redirect: 'follow',
+  })
+  storeCookies(res)
+  const html = await res.text()
+  const csrf = (html.match(/name="ol-csrfToken" content="([^"]+)"/) || [])[1]
+  if (!csrf) {
+    console.error(
+      '错误：未能在分享页找到 CSRF token，链接可能已失效或未开启链接分享。\n' +
+        'Error: CSRF token not found on the share page; the link may be invalid or link-sharing is off.'
+    )
+    process.exit(4)
+  }
+
+  // 2) 调用 grant 接口换取 projectId / call grant to obtain the projectId
+  const grantPath = isReadOnly ? `/read/${token}/grant` : `/${token}/grant`
+  logStep(`请求访问授权 / requesting access grant: ${grantPath}`)
+  res = await fetch(origin + grantPath, {
+    method: 'POST',
+    headers: {
+      'User-Agent': UA,
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrf,
+      Cookie: cookieHeader(),
+      Referer: origin + pagePath,
+    },
+    body: JSON.stringify({ confirmedByUser: true, tokenHashPrefix: hashPrefix }),
+  })
+  storeCookies(res)
+  const grant = await res.json().catch(() => ({}))
+  const redirect = grant.redirect || ''
+  const projectId = (redirect.match(/\/project\/([a-f0-9]{24})/) || [])[1]
+  if (!projectId) {
+    console.error(
+      '错误：未能获取 projectId（匿名访问可能被拒，读写链接需要登录）。服务器返回：\n' +
+        'Error: could not obtain projectId (anonymous access may be denied; read-write links need login). Server said:\n' +
+        JSON.stringify(grant)
+    )
+    process.exit(5)
+  }
+  logStep(`projectId = ${projectId}`)
+
+  // 3) 尽力探测编译器 / TeXLive 版本 / 主文件（通过 realtime socket，可能失败）
+  //    Best-effort probe of compiler / TeX Live image / root doc via the realtime socket (may fail).
+  let probed = { compiler: null, imageName: null, rootDocId: null, name: null, rootDocPath: null }
+  try {
+    probed = await probeViaSocket(origin, projectId, cookieHeader())
+    if (probed.compiler) logStep(`socket 探测成功 / socket probe ok: compiler=${probed.compiler}, imageName=${probed.imageName}`)
+  } catch (e) {
+    logStep(`socket 探测跳过 / socket probe skipped: ${e.message}`)
+  }
+
+  // 4) 下载项目 zip / download the project zip
+  logStep('下载项目 zip / downloading project zip ...')
+  res = await fetch(origin + `/Project/${projectId}/download/zip`, {
+    headers: { 'User-Agent': UA, Cookie: cookieHeader() },
+    redirect: 'follow',
+  })
+  if (!res.ok) {
+    console.error(`错误：下载 zip 失败 HTTP ${res.status} / Error: zip download failed HTTP ${res.status}`)
+    process.exit(6)
+  }
+  const buf = Buffer.from(await res.arrayBuffer())
+  writeFileSync(zipOut, buf)
+  logStep(`已保存 / saved ${zipOut} (${buf.length} bytes)`)
+
+  // 5) 写出元数据 / write metadata
+  const meta = {
+    link,
+    host: origin,
+    projectId,
+    name: probed.name,
+    compiler: probed.compiler, // 可能为 null / may be null -> 由表单/自动检测补足 / filled by form/auto-detect
+    imageName: probed.imageName, // 例 / e.g. "texlive-full:2025.1"
+    texliveYear: probed.imageName ? (probed.imageName.match(/(\d{4})/) || [])[1] || null : null,
+    rootDocPath: probed.rootDocPath,
+  }
+  writeFileSync(metaOut, JSON.stringify(meta, null, 2))
+  logStep(`已保存元数据 / saved metadata ${metaOut}`)
+  console.log(JSON.stringify(meta))
+}
+
+// realtime socket 探测：连接 socket.io 0.9 websocket，读取 joinProjectResponse
+// realtime socket probe: connect the socket.io 0.9 websocket and read joinProjectResponse
+async function probeViaSocket(origin, projectId, cookie) {
+  let WS
+  try {
+    WS = (await import('ws')).default // 可选依赖 / optional dependency
+  } catch {
+    throw new Error('ws 模块不可用 / ws module unavailable')
+  }
+  const host = new URL(origin).host
+  // socket.io 0.9 握手 / handshake
+  const hs = await fetch(`${origin}/socket.io/1/?projectId=${projectId}&t=${Date.now()}`, {
+    headers: { 'User-Agent': UA, Cookie: cookie },
+  })
+  const sid = (await hs.text()).split(':')[0]
+  if (!sid) throw new Error('握手失败 / handshake failed')
+  return await new Promise((resolve, reject) => {
+    const ws = new WS(`wss://${host}/socket.io/1/websocket/${sid}?projectId=${projectId}`, {
+      headers: { Cookie: cookie, Origin: origin, 'User-Agent': UA },
+    })
+    const timer = setTimeout(() => {
+      ws.terminate()
+      reject(new Error('超时 / timeout'))
+    }, 8000)
+    ws.on('error', e => {
+      clearTimeout(timer)
+      reject(new Error(e.message))
+    })
+    ws.on('message', raw => {
+      const d = raw.toString()
+      if (d === '2::') return ws.send('2::') // 心跳 / heartbeat
+      if (d.startsWith('5:')) {
+        try {
+          const msg = JSON.parse(d.slice(d.indexOf(':::') + 3))
+          if (msg.name === 'joinProjectResponse') {
+            const p = msg.args[0].project
+            const rootDocPath = findDocPath(p.rootFolder?.[0], p.rootDoc_id)
+            clearTimeout(timer)
+            ws.terminate()
+            resolve({
+              compiler: p.compiler || null,
+              imageName: p.imageName || null,
+              rootDocId: p.rootDoc_id || null,
+              name: p.name || null,
+              rootDocPath,
+            })
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    })
+  })
+}
+
+// 在文件树里按 doc id 找到主文件相对路径 / locate root doc path in the folder tree by id
+function findDocPath(folder, docId, prefix = '') {
+  if (!folder || !docId) return null
+  for (const d of folder.docs || []) {
+    if (d._id === docId) return prefix + d.name
+  }
+  for (const f of folder.folders || []) {
+    const r = findDocPath(f, docId, prefix + f.name + '/')
+    if (r) return r
+  }
+  return null
+}
+
+main().catch(e => {
+  console.error('未捕获错误 / uncaught error:', e.stack || e.message)
+  process.exit(1)
+})

--- a/scripts/parse-issue-form.mjs
+++ b/scripts/parse-issue-form.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// 解析 “TeXLive Image Bug” issue 表单正文，输出 link/compiler/texlive/main
+// Parse the "TeXLive Image Bug" issue form body and emit link/compiler/texlive/main.
+//
+// 正文从环境变量 ISSUE_BODY 读取；按 "### <标签>" 分节，依据标签里的稳定英文关键字匹配字段。
+// Body is read from env ISSUE_BODY; split on "### <label>" and matched by a stable English keyword in each label.
+//
+// 输出 / Output (stdout, 适合写入 $GITHUB_OUTPUT / suitable for $GITHUB_OUTPUT):
+//   link=...
+//   compiler=auto|pdflatex|xelatex|lualatex|latex
+//   texlive=auto|2026|2025|...
+//   main=<path or empty>
+
+const body = (process.env.ISSUE_BODY || '').replace(/\r/g, '')
+const sections = {}
+for (const chunk of body.split(/\n###\s+/)) {
+  const nl = chunk.indexOf('\n')
+  if (nl < 0) continue
+  const heading = chunk.slice(0, nl).trim()
+  let value = chunk.slice(nl + 1).trim()
+  if (value === '_No response_' || value === '_无回应_') value = ''
+  sections[heading] = value
+}
+
+// 按标签中的英文关键字归类 / classify by English keyword in the label
+function pick(keyword) {
+  for (const [h, v] of Object.entries(sections)) {
+    if (h.toLowerCase().includes(keyword.toLowerCase())) return v
+  }
+  return ''
+}
+
+const rawLink = pick('share link')
+const rawCompiler = pick('Compiler')
+const rawTexlive = pick('TeX Live version')
+const rawMain = pick('Main file')
+
+// 链接：仅接受白名单格式的 overleaf.com https 链接，否则置空（由后续步骤报错）
+// link: only accept an allowlisted overleaf.com https link, else empty (later step reports the error)
+const linkMatch = rawLink.match(
+  /https:\/\/(?:[a-z0-9-]+\.)*overleaf\.com\/(?:read\/[A-Za-z0-9]+|[A-Za-z0-9]+)(?:#[A-Za-z0-9]+)?/
+)
+const link = linkMatch ? linkMatch[0] : ''
+
+// 编译器：识别已知引擎，否则 auto / compiler: recognise a known engine, else auto
+let compiler = 'auto'
+const cl = rawCompiler.toLowerCase()
+if (cl.includes('pdflatex')) compiler = 'pdflatex'
+else if (cl.includes('xelatex')) compiler = 'xelatex'
+else if (cl.includes('lualatex')) compiler = 'lualatex'
+else if (/\blatex\b/.test(cl) && !cl.includes('xelatex') && !cl.includes('lualatex') && !cl.includes('pdflatex'))
+  compiler = 'latex'
+
+// TeXLive 年份：取 4 位年份，否则 auto / TeX Live year: a 4-digit year, else auto
+const ym = rawTexlive.match(/(20\d{2})/)
+const texlive = ym ? ym[1] : 'auto'
+
+// 主文件：取首行非空文本；若不是安全的相对 .tex 路径则置空（改为自动检测）
+// main file: first non-empty line; if not a safe relative .tex path, drop it (fall back to auto-detect)
+let main = (rawMain.split('\n').map(s => s.trim()).find(Boolean) || '').replace(/^`|`$/g, '')
+if (main && (main.startsWith('/') || main.includes('..') || !/^[A-Za-z0-9._/ -]+\.tex$/.test(main))) {
+  main = ''
+}
+
+process.stdout.write(`link=${link}\n`)
+process.stdout.write(`compiler=${compiler}\n`)
+process.stdout.write(`texlive=${texlive}\n`)
+process.stdout.write(`main=${main}\n`)


### PR DESCRIPTION
## 这是什么 / What

一套用于 **“官方 Overleaf 能编译，但本镜像 (ayaka-notes) 编译不了”** 的反馈 + 自动复现流程。
A report-and-reproduce flow for **"compiles on official Overleaf but fails with the ayaka-notes image"**.

用户在 issue 表单里填 **Overleaf 只读分享链接**（+ 编译器 / TeXLive 年份 / 主文件），机器人自动：
A user submits an **Overleaf read-only share link** (+ compiler / TeX Live year / main file) and the bot:
1. 抓取会话、下载项目 zip / grabs a session and downloads the project zip
2. 在 `ghcr.io/ayaka-notes/texlive-full:<year>.1` 里用 `latexmk` 复现编译 / reproduces the compile with `latexmk`
3. 把 **outputs.zip + PDF + 首页预览 + 日志** 贴回 issue / posts **outputs.zip + PDF + preview + logs** back to the issue

## 新增文件 / Files
- `.github/ISSUE_TEMPLATE/texlive-image-bug.yml` —— 中英双语 issue 表单 / bilingual issue form
- `scripts/overleaf-fetch.mjs` —— 分享链接 → 下载 zip（仅 `https://*.overleaf.com`，防 SSRF）
- `scripts/overleaf-compile-test.sh` —— 解析 + `latexmk` 编译 + 收日志/预览
- `scripts/parse-issue-form.mjs` —— 解析表单（含校验）/ parse form (validated)
- `scripts/clsi-seccomp.json` —— 取自 Overleaf CLSI 的 seccomp 白名单
- `.github/workflows/issue-compile-test.yml`（A，**只读无 token**）+ `issue-compile-comment.yml`（B，特权评论）

## 与 CLSI 完全对齐 / Matches CLSI exactly
`latexmk -cd -jobname=output -auxdir=$COMPILE_DIR -outdir=$COMPILE_DIR -synctex=1 -interaction=batchmode -time -f <engine> main.tex`；
env `HOME=/tmp` `CLSI=1` `PATH=.../texlive/<year>/bin/x86_64-linux/`；
sandbox `--network none --user tex --cap-drop ALL --security-opt no-new-privileges --ulimit cpu=t+5:t+10 --security-opt seccomp=clsi-profile.json`。

## 安全 / Security
- 所有输入白名单校验，含非法字符即拒绝；**绝不**把用户内容内联进 shell（全部走环境变量）。
  All inputs allowlist-validated; user content is **never** inlined into shell (env vars only).
- 不可信 LaTeX 在**断网、无密钥**容器内编译；工作流文件**只引用 `GITHUB_TOKEN`**，敏感 secret（如 `ORGTOKEN`）结构上不可达。
  Untrusted LaTeX compiles in a **network-less, secret-less** container; the workflows reference **only `GITHUB_TOKEN`** — sensitive secrets like `ORGTOKEN` are structurally unreachable.
- 两段式工作流：跑不可信项目的 A **只读、无写权限**；评论/发 release 的 B 从不执行项目内容。
  Two-stage: A (untrusted) is **read-only, no write token**; B (privileged) never executes project content.

## 本地验证 / Verified locally
对真实分享链接：xelatex → 596 KB PDF + 预览；错误编译器 → 正确报 `XeTeX is required`；全部注入输入被拒绝。
Against a real link: xelatex → 596 KB PDF + preview; wrong compiler → correct `XeTeX is required` failure; all injection inputs rejected.

> ⚠️ 注意 / Note: 工作流 B 需要 `contents: write`（用 release 托管 PDF/zip 下载直链）。如不希望，可改为只用 run Artifacts。
> Workflow B needs `contents: write` (to host PDF/zip via release assets). Can be switched to run-Artifacts-only if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)