### PR TITLE
fix: trigger compile test on title prefix too (issue #15 skip)

### DIFF
--- a/.github/ISSUE_TEMPLATE/texlive-image-bug.yml
+++ b/.github/ISSUE_TEMPLATE/texlive-image-bug.yml
@@ -1,27 +1,30 @@
-name: 🐛 TeXLive 镜像编译 Bug / TeXLive Image Bug
-description: 官方 Overleaf 能编译，但本镜像 (ayaka-notes) 编译不了 / Compiles on official Overleaf, but fails with the ayaka-notes image
+name: 🐛 TeXLive Image Bug / TeXLive 镜像编译 Bug
+description: Compiles on official Overleaf, but fails with the ayaka-notes image / 官方 Overleaf 能编译，但本镜像 (ayaka-notes) 编译不了
 title: "[TeXLive Image Bug]: "
 labels: ["texlive-image-bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢反馈！本模板用于：**在官方 Overleaf 上能正常编译，但用我们的 TeXLive 镜像 (ayaka-notes) 却编译失败**的问题。
-        Thanks for reporting! Use this template when a project **compiles on official Overleaf but fails with our TeXLive image (ayaka-notes)**.
+        Thanks for reporting! Use this template when a project **compiles on official Overleaf but fails with our TeXLive image (ayaka-notes/texlive-full)**.
+        感谢反馈！本模板用于：**在官方 Overleaf 上能正常编译，但用我们的 TeXLive 镜像 (ayaka-notes/texlive-full) 却编译失败** 的问题。
 
-        提交后，机器人会用你提供的 **只读分享链接** 自动下载项目，并在对应镜像里用 `latexmk` 复现编译，然后把日志贴回本 issue。
-        After you submit, a bot downloads the project from your **read-only share link**, reproduces the compile with `latexmk` in the matching image, and posts the logs back here.
+        After you submit, a bot downloads the project from your **read-only share link**, reproduces the compile with `latexmk` in the matching image, and posts back the **logs + compiled PDF**.
+        提交后，机器人会用你的 **只读分享链接** 下载项目，在对应镜像里用 `latexmk` 复现编译，并把 **日志 + 编译出的 PDF** 回贴到本 issue。
 
-        > ⚠️ 链接里的内容会被公开下载与编译，请勿包含隐私/未发表内容。
-        > ⚠️ The linked content will be downloaded and compiled publicly — do not include private/unpublished material.
+        > ⚠️ The linked content will be downloaded and compiled **publicly** — do not include private or unpublished material.
+        > ⚠️ 链接内容会被 **公开** 下载与编译，请勿包含隐私或未发表内容。
 
   - type: input
     id: share_link
     attributes:
-      label: Overleaf 只读分享链接 / Overleaf read-only share link
+      label: Overleaf read-only share link / Overleaf 只读分享链接
       description: |
-        在 Overleaf 里：菜单 Menu → Share → 打开 “Anyone with this link can view” → 复制 **View only** 链接（形如 `/read/xxxx#yyyy`）。
-        In Overleaf: Menu → Share → turn on "Anyone with this link can view" → copy the **View only** link (looks like `/read/xxxx#yyyy`).
+        **MUST be the "View only" link** — in Overleaf open `Menu → Share → Turn on link sharing`, then copy the link under **"Anyone with this link can view"**. It contains `/read/` (e.g. `https://www.overleaf.com/read/xxxx#yyyy`).
+        **必须是 “View only / 只读” 链接** —— 在 Overleaf 打开 `菜单 Menu → Share → 打开链接分享`，复制 **“Anyone with this link can view”** 下面那条链接；它带有 `/read/`（例如 `https://www.overleaf.com/read/xxxx#yyyy`）。
+
+        ❌ Do **not** paste the "can edit" link (without `/read/`) — anonymous download of edit links is blocked by Overleaf.
+        ❌ **不要** 粘贴 “can edit / 可编辑” 链接（不带 `/read/`）—— Overleaf 禁止匿名下载可编辑链接。
       placeholder: https://www.overleaf.com/read/xxxxxxxxxxxx#yyyyyy
     validations:
       required: true
@@ -29,12 +32,12 @@ body:
   - type: dropdown
     id: compiler
     attributes:
-      label: 编译器 / Compiler
+      label: Compiler / 编译器
       description: |
-        在 Overleaf 左下角 Menu → Settings → Compiler 查看；不确定就选自动检测。
-        Check it in Overleaf: Menu → Settings → Compiler. If unsure, pick auto-detect.
+        Find it in Overleaf at `Menu → Settings → Compiler`. This must match what you use on Overleaf, otherwise the result is not comparable. If unsure, pick auto-detect.
+        在 Overleaf 的 `菜单 Menu → Settings → Compiler` 查看。务必与你在 Overleaf 上用的一致，否则结果不可比；不确定就选自动检测。
       options:
-        - "自动检测 / Auto-detect"
+        - "Auto-detect / 自动检测"
         - "pdflatex"
         - "xelatex"
         - "lualatex"
@@ -46,12 +49,12 @@ body:
   - type: dropdown
     id: texlive_version
     attributes:
-      label: TeX Live 版本 / TeX Live version
+      label: TeX Live version / TeX Live 版本
       description: |
-        在 Overleaf Menu → Settings → TeX Live version 查看；不确定就选自动（用最新）。
-        Check it in Overleaf: Menu → Settings → TeX Live version. If unsure, pick auto (latest).
+        Find it in Overleaf at `Menu → Settings → TeX Live version`. Picking the same year reproduces the exact toolchain. If unsure, pick auto (uses the latest).
+        在 Overleaf 的 `菜单 Menu → Settings → TeX Live version` 查看。选同一年份可复现完全相同的工具链；不确定就选自动（用最新）。
       options:
-        - "自动 / Auto (latest)"
+        - "Auto (latest) / 自动（用最新）"
         - "2026"
         - "2025"
         - "2024"
@@ -66,39 +69,41 @@ body:
   - type: input
     id: main_file
     attributes:
-      label: 主文件路径（可选）/ Main file path (optional)
+      label: Main file path (optional) / 主文件路径（可选）
       description: |
-        主 .tex 文件相对路径；留空则自动检测（找含 \documentclass 与 \begin{document} 的文件）。
-        Relative path to the main .tex; leave empty to auto-detect (the file with \documentclass and \begin{document}).
+        Relative path to the main `.tex` (the one with `\documentclass` and `\begin{document}`), e.g. `main.tex` or `thesis/main.tex`. Leave empty to auto-detect.
+        主 `.tex` 文件的相对路径（含 `\documentclass` 与 `\begin{document}` 的那个），例如 `main.tex` 或 `thesis/main.tex`。留空则自动检测。
       placeholder: main.tex
 
   - type: textarea
     id: overleaf_evidence
     attributes:
-      label: Overleaf 能编译的证据 + 本镜像的报错 / Proof it compiles on Overleaf + the error here
+      label: Proof it compiles on Overleaf + the error you see here / Overleaf 能编译的证据 + 你在本镜像看到的报错
       description: |
-        例如 Overleaf 编译成功的截图，以及你在本镜像/自建 Overleaf 上看到的报错信息。
-        e.g. a screenshot of a successful Overleaf compile, plus the error you see with this image / your self-hosted Overleaf.
+        Please be specific: a screenshot of the successful Overleaf compile, and the **exact error** from this image / your self-hosted Overleaf (copy the relevant lines from the log, e.g. `! LaTeX Error: File 'xxx.sty' not found`).
+        请尽量具体：Overleaf 编译成功的截图，以及本镜像/你自建 Overleaf 上的 **确切报错**（从日志里复制相关行，例如 `! LaTeX Error: File 'xxx.sty' not found`）。
       placeholder: |
-        Overleaf：编译成功（截图） / compiles fine (screenshot)
-        本镜像 / this image: ! LaTeX Error: File `xxx.sty' not found ...
+        Overleaf: compiles fine (screenshot attached) / 编译成功（已附截图）
+        This image / 本镜像: ! LaTeX Error: File `xxx.sty' not found. ...
+    validations:
+      required: true
 
   - type: textarea
     id: extra
     attributes:
-      label: 其他补充（可选）/ Additional context (optional)
+      label: Additional context (optional) / 其他补充（可选）
       description: |
-        用到的特殊宏包/字体、自建 Overleaf 版本、镜像 tag 等。
-        Special packages/fonts used, self-hosted Overleaf version, image tag, etc.
+        Special packages/fonts used, self-hosted Overleaf version, the exact image tag (e.g. `ghcr.io/ayaka-notes/texlive-full:2025.1`), CPU architecture, etc.
+        用到的特殊宏包/字体、自建 Overleaf 版本、确切的镜像 tag（如 `ghcr.io/ayaka-notes/texlive-full:2025.1`）、CPU 架构等。
 
   - type: checkboxes
     id: confirm
     attributes:
-      label: 确认 / Confirmation
+      label: Confirmation / 确认
       options:
-        - label: "该链接是只读分享链接，且任何人可访问 / The link is a read-only share link accessible to anyone"
+        - label: "The link is a read-only (View only) share link, accessible to anyone / 该链接是只读 (View only) 分享链接，任何人可访问"
           required: true
-        - label: "该项目在官方 Overleaf 上能成功编译 / The project compiles successfully on official Overleaf"
+        - label: "The project compiles successfully on official Overleaf / 该项目在官方 Overleaf 上能成功编译"
           required: true
-        - label: "我已确认链接内容可公开 / I confirm the linked content may be public"
+        - label: "I confirm the linked content may be public / 我已确认链接内容可公开"
           required: true

--- a/.github/workflows/issue-compile-test.yml
+++ b/.github/workflows/issue-compile-test.yml
@@ -46,13 +46,17 @@ concurrency:
 
 jobs:
   compile-test:
+    # 用“标签 或 标题前缀”双判定：即便标签缺失（如标签未创建）也能触发
+    # Gate on label OR title prefix, so it still fires even if the label is missing (e.g. not yet created)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' &&
-        contains(github.event.issue.labels.*.name, 'texlive-image-bug')) ||
+        (contains(github.event.issue.labels.*.name, 'texlive-image-bug') ||
+         startsWith(github.event.issue.title, '[TeXLive Image Bug]'))) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.issue.labels.*.name, 'texlive-image-bug') &&
-        startsWith(github.event.comment.body, '/retest-compile'))
+        startsWith(github.event.comment.body, '/retest-compile') &&
+        (contains(github.event.issue.labels.*.name, 'texlive-image-bug') ||
+         startsWith(github.event.issue.title, '[TeXLive Image Bug]')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
issue #15 被 skip 的原因：`texlive-image-bug` 标签此前不存在，issue 表单无法附加该标签，导致 `if` 守卫为假。

The skip cause: the `texlive-image-bug` label did not exist, so the form couldn't attach it and the job guard was false.

修复 / Fix:
- 已在仓库创建 `texlive-image-bug` 标签（今后表单可正常打标签）/ created the label (future form issues get labeled)
- 守卫改为「标签 **或** 标题前缀 `[TeXLive Image Bug]`」双判定，缺标签也能触发 / guard now matches label **or** the title prefix, so a missing label no longer blocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)